### PR TITLE
Remove unused git part

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -9,7 +9,3 @@ bases:
     run-on:
       - name: "ubuntu"
         channel: "20.04"
-parts:
-  charm:
-    build-packages:
-      - git


### PR DESCRIPTION
## Issue
The `git` part declared in `charmcraft.yaml` is not needed. It can be added to charms that use the template if needed, eliminating the need to add this extra dependency to the packaging process on other charms that don't need it.

## Context
The git part is used to install, for example, python packages that are required by the charm, but using a git URL instead of a package name. In this template, there is no package being listed with a git URL.

## Release Notes
Removed git part from charmcraft.yaml.