### PR TITLE
Use server-side state for charms by default

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -101,4 +101,4 @@ class OperatorTemplateCharm(CharmBase):
 
 
 if __name__ == "__main__":
-    main(OperatorTemplateCharm)
+    main(OperatorTemplateCharm, use_juju_for_storage=True)


### PR DESCRIPTION
Storing data in the SQLite DB is a legacy method of storage which also
requires persistent volumes for operators themselves. Upon pod
recreation the unit-local state is lost.

It would be good to either use the newer method which does not rely on
persistent volumes or provide a recommendation in metadata.yaml on how
to configure this properly since this is a template. This change ops for
the former.