### PR TITLE
Add vscode to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ build/
 __pycache__/
 *.py[cod]
 .idea
+.vscode


### PR DESCRIPTION
Some installations of vscode can get bugged, and start creating trash files on the .vscode folder. Adding it to gitignore would be practical and a little time-saving