### PR TITLE
fix: Set isort line_length to same as other tools

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ line-length = 99
 target-version = ["py38"]
 
 [tool.isort]
+line_length = 99
 profile = "black"
 
 # Linting tools configuration


### PR DESCRIPTION
Without this, isort will make a single import line with 88<n_chars<99 into a multi-line import, and black will convert it back to a single line.  They will never pass at the same time.