### PR TITLE
Fix path in lint codespell command

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -46,7 +46,7 @@ deps =
 commands =
     # uncomment the following line if this charm owns a lib
     # codespell {[vars]lib_path}
-    codespell {toxinidir}/. --skip {toxinidir}/.git --skip {toxinidir}/.tox \
+    codespell {toxinidir} --skip {toxinidir}/.git --skip {toxinidir}/.tox \
       --skip {toxinidir}/build --skip {toxinidir}/lib --skip {toxinidir}/venv \
       --skip {toxinidir}/.mypy_cache --skip {toxinidir}/icon.svg
     # pflake8 wrapper supports config from pyproject.toml


### PR DESCRIPTION
`codespell {toxinidir}/.` breaks in `tox` v4