### PR TITLE
fix: linting by pinning flake8 and editing codespell usage

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -35,7 +35,7 @@ commands =
 description = Check code against coding style standards
 deps =
     black
-    flake8
+    flake8<6
     flake8-docstrings
     flake8-copyright
     flake8-builtins
@@ -46,9 +46,9 @@ deps =
 commands =
     # uncomment the following line if this charm owns a lib
     # codespell {[vars]lib_path}
-    codespell {toxinidir} --skip {toxinidir}/.git --skip {toxinidir}/.tox \
-      --skip {toxinidir}/build --skip {toxinidir}/lib --skip {toxinidir}/venv \
-      --skip {toxinidir}/.mypy_cache --skip {toxinidir}/icon.svg
+    codespell {toxinidir}/. --skip {toxinidir}/./.git --skip {toxinidir}/./.tox \
+      --skip {toxinidir}/./build --skip {toxinidir}/./lib --skip {toxinidir}/./venv \
+      --skip {toxinidir}/./.mypy_cache --skip {toxinidir}/icon.svg
     # pflake8 wrapper supports config from pyproject.toml
     pflake8 {[vars]all_path}
     isort --check-only --diff {[vars]all_path}


### PR DESCRIPTION
Pins flake8<6 to address an incompatability with the flake8-copyright plugin (see #39), and refactors the invocation of codespell to address #43.

Fixes #39 and #43